### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Documentation/Restful.md
+++ b/Documentation/Restful.md
@@ -1,4 +1,4 @@
-##Restful API Document
+## Restful API Document
 - 均用POST 采用Basic authentic进行认证
 
 <h4>1. 私信推送</h4>

--- a/Documentation/qk.md
+++ b/Documentation/qk.md
@@ -1,9 +1,9 @@
-#Quick-Know 中文文档
+# Quick-Know 中文文档
 
 Quick-Know是一个高可用的推送集群服务。
 可创建多个App级用户，其下可以创建多个Client终端用户。Client级用户的消息由App级用户进行管理和消息推送。
 
-##特性
+## 特性
 - 易部署
 - 使用Etcd做故障转移及配置文件的分享
 - 多数据库支持
@@ -20,7 +20,7 @@ Quick-Know是一个高可用的推送集群服务。
 - 应用层心跳，保证用户在线可靠性
 - 完善的Restful API，为用户提供全面的对App操作
 
-##架构
+## 架构
 ![quick-know](https://raw.githubusercontent.com/Alienero/quick-know/master/Documentation/img/qk.png "Quick-know")
 
 ## 快速开始

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Quick-Know
 ==========
 QK is a High Available push server cluster
 
-##Features
+## Features
  * Support push private message   
  * Support subscription message group   
  * Support a key multi subscription   


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
